### PR TITLE
Migrate code to move 2024

### DIFF
--- a/contract/Move.lock
+++ b/contract/Move.lock
@@ -20,3 +20,8 @@ source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testn
 dependencies = [
   { name = "MoveStdlib" },
 ]
+
+[move.toolchain-version]
+compiler-version = "1.24.0"
+edition = "legacy"
+flavor = "sui"

--- a/contract/Move.toml
+++ b/contract/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "multisig_tic_tac_toe"
 version = "0.0.1"
+edition = "2024.beta"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }

--- a/contract/sources/multisig_tic_tac_toe.move
+++ b/contract/sources/multisig_tic_tac_toe.move
@@ -7,12 +7,6 @@
 /// 1. Events for triggering client updates.
 /// 2. Clock for preventing player hanging the game.
 module multisig_tic_tac_toe::multisig_tic_tac_toe {
-    use std::vector;
-    use std::option::{Self, Option};
-
-    use sui::object::{Self, UID, ID};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
 
     const MARK_EMPTY: u8 = 0;
     const MARK_X: u8 = 1;
@@ -23,7 +17,7 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
     const EMarkIsFromDifferentGame: u64 = 2;
 
     /// Passed to the winner of the TicTacToe game.
-    struct TicTacToeTrophy has key {
+    public struct TicTacToeTrophy has key {
         id: UID,
         winner: address,
         loser: address,
@@ -34,7 +28,7 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
 
     /// TicTacToe struct should be owned by the game-admin.
     /// This should be the multisig 1-out-of-2 account for both players to make moves.
-    struct TicTacToe has key {
+    public struct TicTacToe has key {
         id: UID,
         /// Column major 3x3 game board
         gameboard: vector<u8>,
@@ -47,7 +41,7 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
     }
 
     /// Mark is passed between game-admin (Multisig 1-out-of-2), x-player and o-player.
-    struct Mark has key {
+    public struct Mark has key {
         id: UID,
         /// Column major 3x3 placement
         placement: Option<u8>,
@@ -79,22 +73,22 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
             id: object::new(ctx),
             placement: option::none(),
             during_turn: true, // Mark is passed to x_addr
-            game_owners: tx_context::sender(ctx),
+            game_owners: ctx.sender(),
             game_id
         };
 
-        transfer::transfer(tic_tac_toe, tx_context::sender(ctx));
+        transfer::transfer(tic_tac_toe, ctx.sender());
         transfer::transfer(mark, x_addr);
     }
 
     /// This is called by the one of the two addresses participating in the multisig, but not from
     /// the multisig itself.
     /// row: [0 - 2], col: [0 - 2]
-    public fun send_mark_to_game(mark: Mark, row: u8, col: u8) {
+    public fun send_mark_to_game(mut mark: Mark, row: u8, col: u8) {
         // Mark.during_turn prevents multisig-acc from editing mark.placement after it has been sent to it.
         assert!(mark.during_turn, ETriedToCheat);
 
-        option::fill(&mut mark.placement, get_index(row, col));
+        mark.placement.fill(get_index(row, col));
         mark.during_turn = false;
         let game_owners = mark.game_owners;
         transfer::transfer(mark, game_owners);
@@ -102,12 +96,12 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
 
     /// This is called by the multisig account to execute the last move by the player who used
     /// `send_mark_to_game`.
-    public fun place_mark(game: &mut TicTacToe, mark: Mark, ctx: &mut TxContext) {
+    public fun place_mark(game: &mut TicTacToe, mut mark: Mark, ctx: &mut TxContext) {
         assert!(mark.game_id == object::uid_to_inner(&game.id), EMarkIsFromDifferentGame);
 
-        let addr = get_cur_turn_address(game);
+        let mut addr = game.get_cur_turn_address();
         // Note here we empty the option
-        let placement: u8 = option::extract(&mut mark.placement);
+        let placement: u8 = mark.placement.extract();
         if (get_cell_by_index(&game.gameboard, placement) != MARK_EMPTY) {
             mark.during_turn = true;
             transfer::transfer(mark, addr);
@@ -120,14 +114,14 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
         } else {
             MARK_O
         };
-        *vector::borrow_mut(&mut game.gameboard, (placement as u64)) = mark_symbol;
+        * &mut game.gameboard[placement as u64] = mark_symbol;
 
         // Check for winner
-        let winner = get_winner(game);
+        let mut winner = game.get_winner();
 
         // Game ended!
-        if (option::is_some(&winner)) {
-            let played_as = option::extract(&mut winner);
+        if (winner.is_some()) {
+            let played_as = winner.extract();
             let (winner, loser, finished) = if (played_as == MARK_X) {
                 (game.x_addr, game.o_addr, 1)
             } else {
@@ -145,18 +139,18 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
                 winner
             );
 
-            delete_mark(mark);
+            mark.delete();
             * &mut game.finished = finished;
             return
         } else if (game.cur_turn >= 8) {    // Draw
-            delete_mark(mark);
+            mark.delete();
             * &mut game.finished = 3;
             return
         };
 
         // Next turn
         * &mut game.cur_turn = game.cur_turn + 1;
-        addr = get_cur_turn_address(game);
+        addr = game.get_cur_turn_address();
         mark.during_turn = true;
         transfer::transfer(mark, addr);
     }
@@ -186,6 +180,8 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
         } = trophy;
         object::delete(id);
     }
+
+    use fun delete_mark as Mark.delete;
 
     /// Internal: Only called when the game is finished
     fun delete_mark(mark: Mark) {
@@ -223,40 +219,40 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
         let p22 = get_cell(&game.gameboard, 2, 2);
 
         // Check all rows
-        let win_mark = check_for_winner(p00, p01, p02);
-        if (option::is_some(&win_mark)) {
+        let mut win_mark = check_for_winner(p00, p01, p02);
+        if (win_mark.is_some()) {
             return win_mark
         };
         win_mark = check_for_winner(p10, p11, p12);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
         win_mark = check_for_winner(p20, p21, p22);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
 
         // Check all columns
         win_mark = check_for_winner(p00, p10, p20);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
         win_mark = check_for_winner(p01, p11, p21);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
         win_mark = check_for_winner(p02, p12, p22);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
 
         // Check diagonals
         win_mark = check_for_winner(p00, p11, p22);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
         win_mark = check_for_winner(p02, p11, p20);
-        if (option::is_some(&win_mark)) {
+        if (win_mark.is_some()) {
             return win_mark
         };
         option::none()
@@ -272,15 +268,15 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
 
     /// Gets column major cell from 3x3 matrix
     fun get_cell(mat33: &vector<u8>, row: u8, col: u8): u8 {
-        assert!(vector::length(mat33) == 9, EInvalidSize);
+        assert!(mat33.length() == 9, EInvalidSize);
         let index = get_index(row, col);
 
-        *vector::borrow(mat33, (index as u64))
+        mat33[index as u64]
     }
 
     fun get_cell_by_index(mat33: &vector<u8>, index: u8): u8 {
         assert!(index < 9, EInvalidSize);
-        *vector::borrow(mat33, (index as u64))
+        mat33[index as u64]
     }
 
     /// Gets column major index from 3x3 matrix
@@ -295,7 +291,7 @@ module multisig_tic_tac_toe::multisig_tic_tac_toe {
     public fun create_fake_mark(placement: Option<u8>, game_owners: address): Mark {
         let id = object::new(&mut tx_context::dummy());
         let game_id = object::uid_to_inner(&id);
-        let during_turn = option::is_none(&placement);
+        let during_turn = placement.is_none();
         Mark {
             id,
             placement,

--- a/contract/tests/test_multisig_tic_tac_toe.move
+++ b/contract/tests/test_multisig_tic_tac_toe.move
@@ -1,7 +1,5 @@
 #[test_only]
 module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
-    use std::option;
-    use std::vector;
     use sui::test_scenario;
     use multisig_tic_tac_toe::multisig_tic_tac_toe::{Self, Mark, TicTacToe, TicTacToeTrophy};
 
@@ -13,23 +11,23 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            test_scenario::return_to_sender(scenario, game);
-            let mark = test_scenario::take_from_address<Mark>(scenario, x_addr);
+            let game = scenario.take_from_sender<TicTacToe>();
+            scenario.return_to_sender(game);
+            let mark = scenario.take_from_address<Mark>(x_addr);
             test_scenario::return_to_address(x_addr, mark);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     // Tests that mark is send successfully to TicTacToe owner
@@ -39,106 +37,106 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
         // Create AdminCap
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_address<Mark>(scenario, x_addr);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 0, 0);
+            let mark = scenario.take_from_address<Mark>(x_addr);
+            mark.send_mark_to_game(0, 0);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            test_scenario::return_to_sender(scenario, mark);
+            let mark = scenario.take_from_sender<Mark>();
+            scenario.return_to_sender(mark);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     // Tests that a player cannot give invalid row/col
     #[test]
-    #[expected_failure(abort_code = multisig_tic_tac_toe::multisig_tic_tac_toe::EInvalidSize)]
+    #[expected_failure(abort_code = ::multisig_tic_tac_toe::multisig_tic_tac_toe::EInvalidSize)]
     fun test_invalid_col_placement() {
         let x_addr = @0x2000;
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 0, 4);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(0, 4);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
-    #[expected_failure(abort_code = multisig_tic_tac_toe::multisig_tic_tac_toe::EInvalidSize)]
+    #[expected_failure(abort_code = ::multisig_tic_tac_toe::multisig_tic_tac_toe::EInvalidSize)]
     fun test_invalid_row_placement() {
         let x_addr = @0x2000;
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 255, 0);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(255, 0);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     // Tests that mark cannot be re-sent to game after send
     #[test]
-    #[expected_failure(abort_code = multisig_tic_tac_toe::multisig_tic_tac_toe::ETriedToCheat)]
+    #[expected_failure(abort_code = ::multisig_tic_tac_toe::multisig_tic_tac_toe::ETriedToCheat)]
     fun test_cheat() {
         let x_addr = @0x2000;
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 0, 1);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(0, 1);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 1, 1);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(1, 1);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     // Test place mark
@@ -148,68 +146,68 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 0, 1);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(0, 1);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
-            test_scenario::return_to_sender(scenario, game);
+            let mut game = scenario.take_from_sender<TicTacToe>();
+            let mark = scenario.take_from_sender<Mark>();
+            game.place_mark(mark, scenario.ctx());
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let mark = test_scenario::take_from_address<Mark>(scenario, o_addr);
+            let mark = scenario.take_from_address<Mark>(o_addr);
             test_scenario::return_to_address(o_addr, mark);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     // Tests that a player cannot place invalid mark
     #[test]
-    #[expected_failure(abort_code = multisig_tic_tac_toe::multisig_tic_tac_toe::EMarkIsFromDifferentGame)]
+    #[expected_failure(abort_code = ::multisig_tic_tac_toe::multisig_tic_tac_toe::EMarkIsFromDifferentGame)]
     fun test_invalid_mark() {
         let x_addr = @0x2000;
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, 0, 1);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(0, 1);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
+            let mut game = scenario.take_from_sender<TicTacToe>();
             let mark = multisig_tic_tac_toe::create_fake_mark(option::some(2), multisig_addr);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             test_scenario::return_to_address(multisig_addr, game);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -220,49 +218,49 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let row = 0;
         let col = 1;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, x_addr);
+        scenario.next_tx(x_addr);
         {
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::send_mark_to_game(mark, row, col);
+            let mark = scenario.take_from_sender<Mark>();
+            mark.send_mark_to_game(row, col);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
-            test_scenario::return_to_sender(scenario, game);
+            let mut game = scenario.take_from_sender<TicTacToe>();
+            let mark = scenario.take_from_sender<Mark>();
+            game.place_mark(mark, scenario.ctx());
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let mark = test_scenario::take_from_address<Mark>(scenario, o_addr);
-            multisig_tic_tac_toe::send_mark_to_game(mark, row, col);
+            let mark = scenario.take_from_address<Mark>(o_addr);
+            mark.send_mark_to_game(row, col);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            let mark = test_scenario::take_from_sender<Mark>(scenario);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
-            test_scenario::return_to_sender(scenario, game);
+            let mut game = scenario.take_from_sender<TicTacToe>();
+            let mark = scenario.take_from_sender<Mark>();
+            game.place_mark(mark, scenario.ctx());
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let mark = test_scenario::take_from_address<Mark>(scenario, o_addr);
+            let mark = scenario.take_from_address<Mark>(o_addr);
             test_scenario::return_to_address(o_addr, mark);
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -271,51 +269,51 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
         //  0 | 3 | 6     X | O | O
         // -----------    ----------
-        //  1 | 4 | 7  ->   | X |  
+        //  1 | 4 | 7  ->   | X |
         // -----------    ----------
         //  2 | 5 | 8       |   | X
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
+            let mut game = scenario.take_from_sender<TicTacToe>();
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(0, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(3, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(4, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(6, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(8, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let trophy = test_scenario::take_from_address<TicTacToeTrophy>(scenario, x_addr);
+            let trophy = scenario.take_from_address<TicTacToeTrophy>(x_addr);
             test_scenario::return_to_address(x_addr, trophy);
 
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            multisig_tic_tac_toe::delete_game(game);
+            let game = scenario.take_from_sender<TicTacToe>();
+            game.delete_game();
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -324,54 +322,54 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
         //  0 | 3 | 6     X | X | O
         // -----------    ----------
-        //  1 | 4 | 7  ->   | O |  
+        //  1 | 4 | 7  ->   | O |
         // -----------    ----------
         //  2 | 5 | 8     O |   | X
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
+            let mut game = scenario.take_from_sender<TicTacToe>();
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(0, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(2, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(3, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(6, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(8, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(4, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let trophy = test_scenario::take_from_address<TicTacToeTrophy>(scenario, o_addr);
+            let trophy = scenario.take_from_address<TicTacToeTrophy>(o_addr);
             test_scenario::return_to_address(o_addr, trophy);
 
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            multisig_tic_tac_toe::delete_game(game);
+            let game = scenario.take_from_sender<TicTacToe>();
+            game.delete_game();
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
 
@@ -381,12 +379,12 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
         //  0 | 3 | 6     X | O | O
@@ -394,71 +392,71 @@ module multisig_tic_tac_toe::test_multisig_tic_tac_toe {
         //  1 | 4 | 7  -> O | X | X
         // -----------    ----------
         //  2 | 5 | 8     X | X | O
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
+            let mut game = scenario.take_from_sender<TicTacToe>();
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(0, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(1, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(2, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(3, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(4, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(6, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(5, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // o-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(8, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
             // x-turn
             let mark = multisig_tic_tac_toe::create_legit_mark(7, multisig_addr, &game);
-            multisig_tic_tac_toe::place_mark(&mut game, mark, test_scenario::ctx(scenario));
+            game.place_mark(mark, scenario.ctx());
 
-            test_scenario::return_to_sender(scenario, game);
+            scenario.return_to_sender(game);
         };
 
-        let effects = test_scenario::next_tx(scenario, multisig_addr);
-        assert!(vector::length(&test_scenario::created(&effects)) == 0, 0);
+        let effects = scenario.next_tx(multisig_addr);
+        assert!(test_scenario::created(&effects).length() == 0, 0);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            multisig_tic_tac_toe::delete_game(game);
+            let game = scenario.take_from_sender<TicTacToe>();
+            game.delete_game();
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
-    #[expected_failure(abort_code = multisig_tic_tac_toe::multisig_tic_tac_toe::ETriedToCheat)]
+    #[expected_failure(abort_code = ::multisig_tic_tac_toe::multisig_tic_tac_toe::ETriedToCheat)]
     fun test_illegal_delete() {
         let x_addr = @0x2000;
         let o_addr = @0x0010;
         let multisig_addr = @0x2010;
 
-        let scenario_val = test_scenario::begin(multisig_addr);
+        let mut scenario_val = test_scenario::begin(multisig_addr);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            multisig_tic_tac_toe::create_game(x_addr, o_addr, test_scenario::ctx(scenario));
+            multisig_tic_tac_toe::create_game(x_addr, o_addr, scenario.ctx());
         };
 
-        test_scenario::next_tx(scenario, multisig_addr);
+        scenario.next_tx(multisig_addr);
         {
-            let game = test_scenario::take_from_sender<TicTacToe>(scenario);
-            multisig_tic_tac_toe::delete_game(game);
+            let game = scenario.take_from_sender<TicTacToe>();
+            game.delete_game();
         };
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }


### PR DESCRIPTION
This migrates the example to Move 2024 Beta.

Testing was done in two ways:

1. Comparing the bytecode before and after migration for the main code (no change)
2. Migrating the tests to Move 2024, and ensuring they still run

Careful review would be appreciated here.